### PR TITLE
Fix panic format

### DIFF
--- a/yew_form/Cargo.toml
+++ b/yew_form/Cargo.toml
@@ -12,6 +12,6 @@ categories = [ "web-programming" ]
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-validator = "0.12.0"
-validator_derive = "0.12.0"
-yew = "0.17"
+validator = "0.14.0"
+validator_derive = "0.14.0"
+yew = "0.18"

--- a/yew_form/src/checkbox.rs
+++ b/yew_form/src/checkbox.rs
@@ -62,8 +62,8 @@ impl<T: Model + Clone> Component for CheckBox<T> {
         html! {
             <input
                 type="checkbox"
-                value=self.props.field_name
-                onclick=self.link.callback(|e| CheckBoxMessage::OnToggle)
+                value=self.props.field_name.clone()
+                onclick=self.link.callback(|_e| CheckBoxMessage::OnToggle)
                 checked=self.value()
                 class="form-check-input form-input"
              />

--- a/yew_form/src/field.rs
+++ b/yew_form/src/field.rs
@@ -110,10 +110,10 @@ impl<T: Model> Component for Field<T> {
     fn view(&self) -> Html {
         html! {
             <input
-                class=self.class()
-                id=self.field_name
-                type=self.input_type
-                placeholder=self.placeholder
+                class=self.class().to_string()
+                id=self.field_name.clone()
+                type=self.input_type.clone()
+                placeholder=self.placeholder.clone()
                 value=self.form.field_value(&self.field_name)
                 oninput=self.link.callback(|e: InputData| FieldMessage::OnInput(e))
             />

--- a/yew_form_derive/src/lib.rs
+++ b/yew_form_derive/src/lib.rs
@@ -69,7 +69,7 @@ pub fn derive_model(input: TokenStream) -> TokenStream {
                     #(
                     #field_names => self.#field_idents.value(suffix),
                     )*
-                    _ => panic!(format!("Field {} does not exist in {}", field_path, stringify!(#struct_name)))
+                    _ => panic!("Field {} does not exist in {}", field_path, stringify!(#struct_name))
                 }
             }
 
@@ -80,7 +80,7 @@ pub fn derive_model(input: TokenStream) -> TokenStream {
                     #(
                     #field_names => self.#field_idents.set_value(suffix, value),
                     )*
-                    _ => panic!(format!("Field {} does not exist in {}", field_path, stringify!(#struct_name)))
+                    _ => panic!("Field {} does not exist in {}", field_path, stringify!(#struct_name))
                 }
             }
         }


### PR DESCRIPTION
Rust compiler generate messages like:
```
warning: panic message is not a string literal
   --> /Users/........../login_component.rs:179:10
    |
179 | #[derive(Model, Validate, PartialEq, Clone, Debug)]
    |          ^^^^^
    |
    = note: this is no longer accepted in Rust 2021
    = note: the panic!() macro supports formatting, so there's no need for the format!() macro here
    = note: this warning originates in a derive macro (in Nightly builds, run with -Z macro-backtrace for more info)
```

This PR will remove these warning